### PR TITLE
feat: infocard update on select left right

### DIFF
--- a/darkstat/front/bases.templ
+++ b/darkstat/front/bases.templ
@@ -61,14 +61,7 @@ templ BasesTable(bases []configs_export.Base, pinm PinMod) {
 					<td>{ fmt.Sprintf("%.0f", base.Pos.Z) }</td>
 					<td>{ strconv.Itoa(base.StridName) }</td>
 					<td>{ strconv.Itoa(base.InfocardID) }</td>
-					<td
-						id={ "infocard_click" + base.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(base.Infocard) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + base.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(base.Infocard, base.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/cms.templ
+++ b/darkstat/front/cms.templ
@@ -64,14 +64,7 @@ templ CmTable(cms []configs_export.CounterMeasure, pinm PinMod, disco fronttypes
 					<td>{ cm.Nickname } </td>
 					<td>{ strconv.Itoa(cm.NameID) } </td>
 					<td>{ strconv.Itoa(cm.InfoID) } </td>
-					<td
-						id={ "infocard_click" + cm.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(cm.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + cm.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(cm.Nickname), cm.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/commodities.templ
+++ b/darkstat/front/commodities.templ
@@ -64,14 +64,7 @@ templ CommodityTable(commodities []configs_export.Commodity, pinm PinMod) {
 					<td>{ commodity.Nickname }</td>
 					<td>{ strconv.Itoa(commodity.NameID) }</td>
 					<td>{ strconv.Itoa(commodity.InfocardID) }</td>
-					<td
-						id={ "infocard_click" + commodity.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(commodity.Infocard) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + commodity.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(commodity.Infocard, commodity.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/engines.templ
+++ b/darkstat/front/engines.templ
@@ -71,14 +71,7 @@ templ EnginesTable(engines []configs_export.Engine, pinm PinMod, disco fronttype
 					<td>{ engine.HpType } </td>
 					<td>{ strconv.Itoa(engine.NameID) } </td>
 					<td>{ strconv.Itoa(engine.InfoID) } </td>
-					<td
-						id={ "infocard_click" + engine.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(engine.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + engine.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(engine.Nickname), engine.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/factions.templ
+++ b/darkstat/front/factions.templ
@@ -75,14 +75,7 @@ templ FactionTable(factions []configs_export.Faction, mode FactionTabMode, pinm 
 					<td>{ fmt.Sprintf("%.2f", faction.MissionAbort) }</td>
 					<td>{ strconv.Itoa(faction.InfonameID) }</td>
 					<td>{ strconv.Itoa(faction.InfocardID) }</td>
-					<td
-						id={ "infocard_click" + faction.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(faction.Infocard) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + faction.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(faction.Infocard, faction.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/guns.templ
+++ b/darkstat/front/guns.templ
@@ -114,14 +114,7 @@ templ GunTable(guns []configs_export.Gun, mode GunTabMode, pinm PinMod, disco fr
 					<td>{ gun.HpType } </td>
 					<td>{ strconv.Itoa(gun.IdsName) } </td>
 					<td>{ strconv.Itoa(gun.IdsInfo) } </td>
-					<td
-						id={ "infocard_click" + gun.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(gun.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + gun.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(gun.Nickname), gun.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/mines.templ
+++ b/darkstat/front/mines.templ
@@ -83,14 +83,7 @@ templ MinesTable(mines []configs_export.Mine, pinm PinMod, disco fronttypes.Disc
 					<td>{ mine.Nickname } </td>
 					<td>{ strconv.Itoa(mine.IdsName) } </td>
 					<td>{ strconv.Itoa(mine.IdsInfo) } </td>
-					<td
-						id={ "infocard_click" + mine.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(mine.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + mine.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(mine.Nickname), mine.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/shared.templ
+++ b/darkstat/front/shared.templ
@@ -455,21 +455,22 @@ templ FilterBar(disco fronttypes.DiscoveryIDs) {
 templ PinSelectLeftRight(pinm PinMod, url string) {
 	if pinm == PinMode {
 		<td
+			class="left-arrow-infocard-trigger"
 			hx-get={ types.GetCtx(ctx).SiteRoot + url }
 			hx-trigger="mousedown consume"
 			hx-target={ "#table-bottom-main" }
 			hx-swap="innerHTML"
 			preload="mouseover"
-			style="cursor:zoom-in;"
-		>To Left</td>
+			style="cursor:zoom-in; text-align: center;"
+		>&#8592;</td>
 		<td
 			hx-get={ types.GetCtx(ctx).SiteRoot + url }
-			hx-trigger="mousedown consume"
+			hx-trigger="mousedown"
 			hx-target={ "#table-bottom-main" + string(pinm) }
 			hx-swap="innerHTML"
 			preload="mouseover"
-			style="cursor:zoom-in;"
-		>To Right</td>
+			style="cursor:zoom-in; text-align: center;"
+		>&#8594;</td>
 	}
 }
 
@@ -486,5 +487,24 @@ templ TdDisco(disco fronttypes.DiscoveryIDs, nickname string, data *configs_expo
 			{ fmt.Sprintf("%.0f%%",(data.TechcompatByID[""]*100)) }
 		</td>
 		<td>{ data.TechCell }</td>
+	}
+}
+
+templ TdInfoCardClick(infocardKey configs_export.InfocardKey, nickname string, pinm PinMod) {
+	if pinm == PinMode {
+		<td
+			hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(infocardKey) }
+			hx-trigger={ "mousedown from:closest tr, click from:previous td.left-arrow-infocard-trigger" }
+			hx-target="#infocard_view"
+			hx-swap="innerHTML"
+		></td>
+	} 
+	else {
+		<td
+			hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(infocardKey) }
+			hx-trigger={ "mousedown from:closest tr" }
+			hx-target="#infocard_view"
+			hx-swap="innerHTML"
+		></td>
 	}
 }

--- a/darkstat/front/shared.templ
+++ b/darkstat/front/shared.templ
@@ -455,7 +455,7 @@ templ FilterBar(disco fronttypes.DiscoveryIDs) {
 templ PinSelectLeftRight(pinm PinMod, url string) {
 	if pinm == PinMode {
 		<td
-			class="left-arrow-infocard-trigger"
+			class="select_left_infocard_trigger"
 			hx-get={ types.GetCtx(ctx).SiteRoot + url }
 			hx-trigger="mousedown consume"
 			hx-target={ "#table-bottom-main" }
@@ -494,7 +494,7 @@ templ TdInfoCardClick(infocardKey configs_export.InfocardKey, nickname string, p
 	if pinm == PinMode {
 		<td
 			hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(infocardKey) }
-			hx-trigger={ "mousedown from:closest tr, click from:previous td.left-arrow-infocard-trigger" }
+			hx-trigger={ "mousedown from:closest tr, click from:previous td.select_left_infocard_trigger" }
 			hx-target="#infocard_view"
 			hx-swap="innerHTML"
 		></td>

--- a/darkstat/front/shields.templ
+++ b/darkstat/front/shields.templ
@@ -75,14 +75,7 @@ templ ShieldTable(shields []configs_export.Shield, pinm PinMod, disco fronttypes
 					<td>{ shield.HpType } </td>
 					<td>{ strconv.Itoa(shield.IdsName) } </td>
 					<td>{ strconv.Itoa(shield.IdsInfo) } </td>
-					<td
-						id={ "infocard_click" + shield.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(shield.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + shield.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(shield.Nickname), shield.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/ships.templ
+++ b/darkstat/front/ships.templ
@@ -113,14 +113,7 @@ templ ShipTable(ships []configs_export.Ship, mode ShipTabMode, pinm PinMod, disc
 					<td>{ ship.Nickname } </td>
 					<td>{ strconv.Itoa(ship.NameID) } </td>
 					<td>{ strconv.Itoa(ship.InfoID) } </td>
-					<td
-						id={ "infocard_click" + ship.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(ship.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + ship.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(ship.Nickname), ship.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/thrusters.templ
+++ b/darkstat/front/thrusters.templ
@@ -65,14 +65,7 @@ templ ThrustersTable(thrusters []configs_export.Thruster, pinm PinMod, disco fro
 					<td>{ thruster.Nickname } </td>
 					<td>{ strconv.Itoa(thruster.NameID) } </td>
 					<td>{ strconv.Itoa(thruster.InfoID) } </td>
-					<td
-						id={ "infocard_click" + thruster.Nickname }
-						hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(thruster.Nickname)) }
-						hx-trigger={ "mousedown from:#" + string(pinm) + "bottominfo_" + thruster.Nickname }
-						hx-target="#infocard_view"
-						hx-swap="innerHTML"
-						preload="mouseover"
-					></td>
+					@TdInfoCardClick(configs_export.InfocardKey(thruster.Nickname), thruster.Nickname, pinm)
 				</tr>
 			}
 		</tbody>

--- a/darkstat/front/tractors.templ
+++ b/darkstat/front/tractors.templ
@@ -57,14 +57,7 @@ templ TractorsT(tractors []configs_export.Tractor, mode2 ShowEmpty) {
 										<td>{ string(tractor.Nickname) } </td>
 										<td>{ strconv.Itoa(tractor.NameID) } </td>
 										<td>{ strconv.Itoa(tractor.InfoID) } </td>
-										<td
-											id={ "infocard_click" + string(tractor.Nickname) }
-											hx-get={ types.GetCtx(ctx).SiteRoot + InfocardURL(configs_export.InfocardKey(tractor.Nickname)) }
-											hx-trigger={ "mousedown from:#bottominfo_" + string(tractor.Nickname) }
-											hx-target="#infocard_view"
-											hx-swap="innerHTML"
-											preload="mouseover"
-										></td>
+										@TdInfoCardClick(configs_export.InfocardKey(tractor.Nickname), string(tractor.Nickname), "")
 									</tr>
 								}
 							</tbody>


### PR DESCRIPTION
Part of the plans for the next release (https://github.com/darklab8/fl-darkstat/issues/22)

> - select left/right should update infocards
>    - When u have pinned items, it has special columns in opened table, for selecting to left and right opened bottom tab. Clicking there should update infocard too


Additionally: 
- add TdInfoCardClick and general Infocard triggers
- replace left and right text with arrows