### PR TITLE
fix: Workaround for a crash in the ini loader

### DIFF
--- a/configs/configs_mapped/parserutils/iniload/configfile.go
+++ b/configs/configs_mapped/parserutils/iniload/configfile.go
@@ -22,6 +22,8 @@ func NewLoader(input_file *file.File) *IniLoader {
 func (fileconfig *IniLoader) Scan() *IniLoader {
 	if fileconfig.input_file == nil {
 		logus.Log.Error("input_file is empty")
+		fileconfig.INIFile = &inireader.INIFile{}
+		return fileconfig
 	}
 
 	iniconfig := inireader.Read(fileconfig.input_file)


### PR DESCRIPTION
```
time=2026-03-05T02:35:18.193-05:00 level=ERROR msg="input_file is empty"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x8 pc=0x7ff66ff40105]

goroutine 117 [running]:
github.com/darklab8/fl-darkstat/configs/configs_mapped/parserutils/filefind/file.(*File).GetFilepath(...)
        /home/krmloo/fl/fl-darkstat/configs/configs_mapped/parserutils/filefind/file/file_handler.go:53
github.com/darklab8/fl-darkstat/configs/configs_mapped/parserutils/inireader.Read(0x0)
        /home/krmloo/fl/fl-darkstat/configs/configs_mapped/parserutils/inireader/inireader.go:336 +0x25
github.com/darklab8/fl-darkstat/configs/configs_mapped/parserutils/iniload.(*IniLoader).Scan(0xc001126c80)
        /home/krmloo/fl/fl-darkstat/configs/configs_mapped/parserutils/iniload/configfile.go:27 +0x4b
github.com/darklab8/fl-darkstat/configs/configs_mapped.(*MappedConfigs).Read.func1.1(0x49444f4d4d4f435c?)
        /home/krmloo/fl/fl-darkstat/configs/configs_mapped/main.go:342 +0x1c
created by github.com/darklab8/fl-darkstat/configs/configs_mapped.(*MappedConfigs).Read.func1 in goroutine 1
        /home/krmloo/fl/fl-darkstat/configs/configs_mapped/main.go:341 +0x50
```

Solves the error above. There's probably a nicer solution somewhere but it at least manages to launch now.